### PR TITLE
Add git utils for shallow cloning and caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,10 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Cache .cache/visilog directory
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/visilog
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 nom = "7.1.3"
+git2 = "0.13.24"
+lazy_static = "1.4.0"

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -29,12 +29,12 @@ pub fn shallow_clone_and_cache(repo_url: &str, commit_hash: &str, subdir: &str) 
     let subdir_oid = subdir_entry.id();
     let subdir_tree = repo.find_tree(subdir_oid)?;
 
-    fs::create_dir_all(&cache_path)?;
+    fs::create_dir_all(&cache_path).map_err(|e| git2::Error::from_str(&e.to_string()))?;
     for entry in subdir_tree.iter() {
         let entry_path = format!("{}/{}", cache_path, entry.name().unwrap());
         if entry.kind() == Some(git2::ObjectType::Blob) {
             let blob = repo.find_blob(entry.id())?;
-            fs::write(entry_path, blob.content())?;
+            fs::write(entry_path, blob.content()).map_err(|e| git2::Error::from_str(&e.to_string()))?;
         }
     }
 

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -1,0 +1,42 @@
+use git2::{Repository, Oid};
+use lazy_static::lazy_static;
+use std::path::Path;
+use std::fs;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref CACHE_DIR: Mutex<String> = Mutex::new(format!("{}/.cache/visilog", std::env::var("HOME").unwrap()));
+}
+
+pub fn initialize_cache_dir(path: &str) {
+    let mut cache_dir = CACHE_DIR.lock().unwrap();
+    *cache_dir = path.to_string();
+}
+
+pub fn shallow_clone_and_cache(repo_url: &str, commit_hash: &str, subdir: &str) -> Result<(), git2::Error> {
+    let cache_dir = CACHE_DIR.lock().unwrap();
+    let cache_path = format!("{}/{}_{}_{}", *cache_dir, repo_url.replace("/", "_"), commit_hash, subdir.replace("/", "_"));
+
+    if Path::new(&cache_path).exists() {
+        return Ok(());
+    }
+
+    let repo = Repository::clone(repo_url, &cache_path)?;
+    let oid = Oid::from_str(commit_hash)?;
+    let commit = repo.find_commit(oid)?;
+    let tree = commit.tree()?;
+    let subdir_entry = tree.get_name(subdir).ok_or(git2::Error::from_str("Subdirectory not found"))?;
+    let subdir_oid = subdir_entry.id();
+    let subdir_tree = repo.find_tree(subdir_oid)?;
+
+    fs::create_dir_all(&cache_path)?;
+    for entry in subdir_tree.iter() {
+        let entry_path = format!("{}/{}", cache_path, entry.name().unwrap());
+        if entry.kind() == Some(git2::ObjectType::Blob) {
+            let blob = repo.find_blob(entry.id())?;
+            fs::write(entry_path, blob.content())?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,25 @@ mod register;
 mod expressions;
 mod parsers;
 mod utils;
+mod git_utils;
 
 use crate::keywords::VerilogKeyword;
 use crate::register::Register;
 use crate::expressions::{VerilogBinaryExpression, ReductionOperator};
 use crate::parsers::*;
 use crate::utils::*;
+use crate::git_utils::shallow_clone_and_cache;
 
 fn main() {
     println!("Hello, world!");
+
+    // Test the shallow_clone_and_cache function
+    let repo_url = "https://github.com/user/repo.git";
+    let commit_hash = "abc123";
+    let subdir = "src";
+
+    match shallow_clone_and_cache(repo_url, commit_hash, subdir) {
+        Ok(_) => println!("Shallow clone and cache successful"),
+        Err(e) => eprintln!("Error: {}", e),
+    }
 }

--- a/src/tests/git_utils_tests.rs
+++ b/src/tests/git_utils_tests.rs
@@ -1,0 +1,26 @@
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git_utils::{initialize_cache_dir, shallow_clone_and_cache};
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn test_shallow_clone_and_cache() {
+        let repo_url = "https://github.com/user/repo.git";
+        let commit_hash = "abc123";
+        let subdir = "src";
+        let cache_dir = "test_cache";
+
+        initialize_cache_dir(cache_dir);
+
+        match shallow_clone_and_cache(repo_url, commit_hash, subdir) {
+            Ok(_) => {
+                let cache_path = format!("{}/{}_{}_{}", cache_dir, repo_url.replace("/", "_"), commit_hash, subdir.replace("/", "_"));
+                assert!(Path::new(&cache_path).exists());
+                fs::remove_dir_all(cache_dir).unwrap();
+            },
+            Err(e) => panic!("Error: {}", e),
+        }
+    }
+}


### PR DESCRIPTION
Add testing utility code for shallow cloning and caching git repositories.

* **Cargo.toml**
  - Add `git2` and `lazy_static` dependencies.

* **src/git_utils.rs**
  - Create a new module `git_utils`.
  - Add function `shallow_clone_and_cache` to perform shallow clone and caching.
  - Use `git2` crate for git operations.
  - Use `lazy_static` for cache directory initialization.
  - Set default cache directory to `.cache/visilog` in the user's home directory.

* **src/main.rs**
  - Add `mod git_utils;` to include the new `git_utils` module.
  - Add a call to `git_utils::shallow_clone_and_cache` in the `main` function for testing.

* **src/tests/git_utils_tests.rs**
  - Create a new test module for `git_utils`.
  - Add tests for `shallow_clone_and_cache` function.

* **.github/workflows/rust.yml**
  - Add caching of `.cache/visilog` directory to the testing action in GitHub Actions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/meawoppl/visilog/pull/9?shareId=f1157bd7-457c-41f8-8f87-add8c911cf55).