### PR TITLE
Add tests for identifier parsing

### DIFF
--- a/src/modules.rs
+++ b/src/modules.rs
@@ -105,10 +105,39 @@ mod tests {
 
     #[test]
     fn test_parse_identifier() {
+        // Tests for valid first characters (letters and underscores), covering both uppercase and lowercase letters
         assert_eq!(parse_identifier("my_module"), Ok(("", "my_module")));
         assert_eq!(parse_identifier("_my_module"), Ok(("", "_my_module")));
+        assert_eq!(parse_identifier("My_Module"), Ok(("", "My_Module")));
+        assert_eq!(parse_identifier("_My_Module"), Ok(("", "_My_Module")));
         assert_eq!(parse_identifier("my_module1"), Ok(("", "my_module1")));
+        assert_eq!(parse_identifier("My_Module1"), Ok(("", "My_Module1")));
+        assert_eq!(parse_identifier("_my_module1"), Ok(("", "_my_module1")));
+        assert_eq!(parse_identifier("_My_Module1"), Ok(("", "_My_Module1")));
+
+        // Tests for invalid first characters (digits and dollar signs)
         assert!(parse_identifier("1my_module").is_err());
+        assert!(parse_identifier("$my_module").is_err());
+        assert!(parse_identifier("1My_Module").is_err());
+        assert!(parse_identifier("$My_Module").is_err());
+
+        // Tests for mixed valid and invalid first characters
+        assert!(parse_identifier("my_module$").is_ok());
+        assert!(parse_identifier("my_module1$").is_ok());
+        assert!(parse_identifier("My_Module$").is_ok());
+        assert!(parse_identifier("My_Module1$").is_ok());
+        assert!(parse_identifier("_my_module$").is_ok());
+        assert!(parse_identifier("_my_module1$").is_ok());
+        assert!(parse_identifier("_My_Module$").is_ok());
+        assert!(parse_identifier("_My_Module1$").is_ok());
+
+        // Tests for identifiers with a length of up to 1024 characters
+        let valid_identifier = "a".repeat(1024);
+        assert!(parse_identifier(&valid_identifier).is_ok());
+
+        // Tests for identifiers exceeding 1024 characters
+        let invalid_identifier = "a".repeat(1025);
+        assert!(parse_identifier(&invalid_identifier).is_err());
     }
 
     #[test]

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -109,11 +109,11 @@ mod tests {
             "my_module", "_my_module", "My_Module", "_My_Module",
             "my_module1", "My_Module1", "_my_module1", "_My_Module1"
         ];
-        for identifier in &valid_identifiers {
+        for id_str in &valid_identifiers {
             assert!(
-                parse_identifier(identifier).is_ok(),
+                parse_identifier(id_str).is_ok(),
                 "Valid identifier {} failed to parse",
-                identifier
+                id_str
             );
         }
     }
@@ -121,11 +121,11 @@ mod tests {
     #[test]
     fn test_parse_identifier_invalid_first_characters() {
         let invalid_identifiers = ["1my_module", "$my_module", "1My_Module", "$My_Module"];
-        for identifier in &invalid_identifiers {
+        for id_str in &invalid_identifiers {
             assert!(
-                parse_identifier(identifier).is_err(),
+                parse_identifier(id_str).is_err(),
                 "Invalid identifier {} should not parse",
-                identifier
+                id_str
             );
         }
     }
@@ -136,11 +136,11 @@ mod tests {
             "my_module$", "my_module1$", "My_Module$", "My_Module1$",
             "_my_module$", "_my_module1$", "_My_Module$", "_My_Module1$"
         ];
-        for identifier in &mixed_identifiers {
+        for id_str in &mixed_identifiers {
             assert!(
-                parse_identifier(identifier).is_ok(),
+                parse_identifier(id_str).is_ok(),
                 "Mixed identifier {} failed to parse",
-                identifier
+                id_str
             );
         }
     }

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -104,40 +104,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_identifier() {
-        // Tests for valid first characters (letters and underscores), covering both uppercase and lowercase letters
-        assert_eq!(parse_identifier("my_module"), Ok(("", "my_module")));
-        assert_eq!(parse_identifier("_my_module"), Ok(("", "_my_module")));
-        assert_eq!(parse_identifier("My_Module"), Ok(("", "My_Module")));
-        assert_eq!(parse_identifier("_My_Module"), Ok(("", "_My_Module")));
-        assert_eq!(parse_identifier("my_module1"), Ok(("", "my_module1")));
-        assert_eq!(parse_identifier("My_Module1"), Ok(("", "My_Module1")));
-        assert_eq!(parse_identifier("_my_module1"), Ok(("", "_my_module1")));
-        assert_eq!(parse_identifier("_My_Module1"), Ok(("", "_My_Module1")));
+    fn test_parse_identifier_valid_first_characters() {
+        let valid_identifiers = [
+            "my_module", "_my_module", "My_Module", "_My_Module",
+            "my_module1", "My_Module1", "_my_module1", "_My_Module1"
+        ];
+        for identifier in &valid_identifiers {
+            assert!(
+                parse_identifier(identifier).is_ok(),
+                "Valid identifier {} failed to parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for invalid first characters (digits and dollar signs)
-        assert!(parse_identifier("1my_module").is_err());
-        assert!(parse_identifier("$my_module").is_err());
-        assert!(parse_identifier("1My_Module").is_err());
-        assert!(parse_identifier("$My_Module").is_err());
+    #[test]
+    fn test_parse_identifier_invalid_first_characters() {
+        let invalid_identifiers = ["1my_module", "$my_module", "1My_Module", "$My_Module"];
+        for identifier in &invalid_identifiers {
+            assert!(
+                parse_identifier(identifier).is_err(),
+                "Invalid identifier {} should not parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for mixed valid and invalid first characters
-        assert!(parse_identifier("my_module$").is_ok());
-        assert!(parse_identifier("my_module1$").is_ok());
-        assert!(parse_identifier("My_Module$").is_ok());
-        assert!(parse_identifier("My_Module1$").is_ok());
-        assert!(parse_identifier("_my_module$").is_ok());
-        assert!(parse_identifier("_my_module1$").is_ok());
-        assert!(parse_identifier("_My_Module$").is_ok());
-        assert!(parse_identifier("_My_Module1$").is_ok());
+    #[test]
+    fn test_parse_identifier_mixed_valid_invalid_first_characters() {
+        let mixed_identifiers = [
+            "my_module$", "my_module1$", "My_Module$", "My_Module1$",
+            "_my_module$", "_my_module1$", "_My_Module$", "_My_Module1$"
+        ];
+        for identifier in &mixed_identifiers {
+            assert!(
+                parse_identifier(identifier).is_ok(),
+                "Mixed identifier {} failed to parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for identifiers with a length of up to 1024 characters
+    #[test]
+    fn test_parse_identifier_length() {
         let valid_identifier = "a".repeat(1024);
-        assert!(parse_identifier(&valid_identifier).is_ok());
+        assert!(
+            parse_identifier(&valid_identifier).is_ok(),
+            "Valid identifier of length 1024 failed to parse"
+        );
 
-        // Tests for identifiers exceeding 1024 characters
         let invalid_identifier = "a".repeat(1025);
-        assert!(parse_identifier(&invalid_identifier).is_err());
+        assert!(
+            parse_identifier(&invalid_identifier).is_err(),
+            "Invalid identifier of length 1025 should not parse"
+        );
     }
 
     #[test]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -171,40 +171,60 @@ mod tests {
     use crate::keywords::ALL_KEYWORDS;
 
     #[test]
-    fn test_identifiers() {
-        // Tests for valid first characters (letters and underscores), covering both uppercase and lowercase letters
-        assert!(identifier("var_a").is_ok());
-        assert!(identifier("_var_a").is_ok());
-        assert!(identifier("Var_A").is_ok());
-        assert!(identifier("_Var_A").is_ok());
-        assert!(identifier("var_a1").is_ok());
-        assert!(identifier("Var_A1").is_ok());
-        assert!(identifier("_var_a1").is_ok());
-        assert!(identifier("_Var_A1").is_ok());
+    fn test_identifiers_valid_first_characters() {
+        let valid_identifiers = [
+            "var_a", "_var_a", "Var_A", "_Var_A",
+            "var_a1", "Var_A1", "_var_a1", "_Var_A1"
+        ];
+        for identifier in &valid_identifiers {
+            assert!(
+                identifier(identifier).is_ok(),
+                "Valid identifier {} failed to parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for invalid first characters (digits and dollar signs)
-        assert!(identifier("1var_a").is_err());
-        assert!(identifier("$var_a").is_err());
-        assert!(identifier("1Var_A").is_err());
-        assert!(identifier("$Var_A").is_err());
+    #[test]
+    fn test_identifiers_invalid_first_characters() {
+        let invalid_identifiers = ["1var_a", "$var_a", "1Var_A", "$Var_A"];
+        for identifier in &invalid_identifiers {
+            assert!(
+                identifier(identifier).is_err(),
+                "Invalid identifier {} should not parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for mixed valid and invalid first characters
-        assert!(identifier("var_a$").is_ok());
-        assert!(identifier("var_a1$").is_ok());
-        assert!(identifier("Var_A$").is_ok());
-        assert!(identifier("Var_A1$").is_ok());
-        assert!(identifier("_var_a$").is_ok());
-        assert!(identifier("_var_a1$").is_ok());
-        assert!(identifier("_Var_A$").is_ok());
-        assert!(identifier("_Var_A1$").is_ok());
+    #[test]
+    fn test_identifiers_mixed_valid_invalid_first_characters() {
+        let mixed_identifiers = [
+            "var_a$", "var_a1$", "Var_A$", "Var_A1$",
+            "_var_a$", "_var_a1$", "_Var_A$", "_Var_A1$"
+        ];
+        for identifier in &mixed_identifiers {
+            assert!(
+                identifier(identifier).is_ok(),
+                "Mixed identifier {} failed to parse",
+                identifier
+            );
+        }
+    }
 
-        // Tests for identifiers with a length of up to 1024 characters
+    #[test]
+    fn test_identifiers_length() {
         let valid_identifier = "a".repeat(1024);
-        assert!(identifier(&valid_identifier).is_ok());
+        assert!(
+            identifier(&valid_identifier).is_ok(),
+            "Valid identifier of length 1024 failed to parse"
+        );
 
-        // Tests for identifiers exceeding 1024 characters
         let invalid_identifier = "a".repeat(1025);
-        assert!(identifier(&invalid_identifier).is_err());
+        assert!(
+            identifier(&invalid_identifier).is_err(),
+            "Invalid identifier of length 1025 should not parse"
+        );
     }
 
     #[test]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -172,12 +172,39 @@ mod tests {
 
     #[test]
     fn test_identifiers() {
+        // Tests for valid first characters (letters and underscores), covering both uppercase and lowercase letters
         assert!(identifier("var_a").is_ok());
+        assert!(identifier("_var_a").is_ok());
+        assert!(identifier("Var_A").is_ok());
+        assert!(identifier("_Var_A").is_ok());
+        assert!(identifier("var_a1").is_ok());
+        assert!(identifier("Var_A1").is_ok());
+        assert!(identifier("_var_a1").is_ok());
+        assert!(identifier("_Var_A1").is_ok());
+
+        // Tests for invalid first characters (digits and dollar signs)
+        assert!(identifier("1var_a").is_err());
         assert!(identifier("$var_a").is_err());
-        assert!(identifier("v$ar_a").is_ok());
-        assert!(identifier("2var").is_err());
-        assert!(identifier("var23_g").is_ok());
-        assert!(identifier("23").is_err());
+        assert!(identifier("1Var_A").is_err());
+        assert!(identifier("$Var_A").is_err());
+
+        // Tests for mixed valid and invalid first characters
+        assert!(identifier("var_a$").is_ok());
+        assert!(identifier("var_a1$").is_ok());
+        assert!(identifier("Var_A$").is_ok());
+        assert!(identifier("Var_A1$").is_ok());
+        assert!(identifier("_var_a$").is_ok());
+        assert!(identifier("_var_a1$").is_ok());
+        assert!(identifier("_Var_A$").is_ok());
+        assert!(identifier("_Var_A1$").is_ok());
+
+        // Tests for identifiers with a length of up to 1024 characters
+        let valid_identifier = "a".repeat(1024);
+        assert!(identifier(&valid_identifier).is_ok());
+
+        // Tests for identifiers exceeding 1024 characters
+        let invalid_identifier = "a".repeat(1025);
+        assert!(identifier(&invalid_identifier).is_err());
     }
 
     #[test]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -176,11 +176,11 @@ mod tests {
             "var_a", "_var_a", "Var_A", "_Var_A",
             "var_a1", "Var_A1", "_var_a1", "_Var_A1"
         ];
-        for identifier in &valid_identifiers {
+        for id_str in &valid_identifiers {
             assert!(
-                identifier(identifier).is_ok(),
+                identifier(id_str).is_ok(),
                 "Valid identifier {} failed to parse",
-                identifier
+                id_str
             );
         }
     }
@@ -188,11 +188,11 @@ mod tests {
     #[test]
     fn test_identifiers_invalid_first_characters() {
         let invalid_identifiers = ["1var_a", "$var_a", "1Var_A", "$Var_A"];
-        for identifier in &invalid_identifiers {
+        for id_str in &invalid_identifiers {
             assert!(
-                identifier(identifier).is_err(),
+                identifier(id_str).is_err(),
                 "Invalid identifier {} should not parse",
-                identifier
+                id_str
             );
         }
     }
@@ -203,11 +203,11 @@ mod tests {
             "var_a$", "var_a1$", "Var_A$", "Var_A1$",
             "_var_a$", "_var_a1$", "_Var_A$", "_Var_A1$"
         ];
-        for identifier in &mixed_identifiers {
+        for id_str in &mixed_identifiers {
             assert!(
-                identifier(identifier).is_ok(),
+                identifier(id_str).is_ok(),
                 "Mixed identifier {} failed to parse",
-                identifier
+                id_str
             );
         }
     }


### PR DESCRIPTION
Add tests for identifier parsing in `src/modules.rs` and `src/parsers.rs`.

* **Valid first characters**:
  - Add tests for valid first characters (letters and underscores), covering both uppercase and lowercase letters in `test_parse_identifier` and `test_identifiers` functions.

* **Invalid first characters**:
  - Add tests for invalid first characters (digits and dollar signs) in `test_parse_identifier` and `test_identifiers` functions.

* **Mixed valid and invalid first characters**:
  - Add tests for mixed valid and invalid first characters in `test_parse_identifier` and `test_identifiers` functions.

* **Identifier length**:
  - Add tests for identifiers with a length of up to 1024 characters in `test_parse_identifier` and `test_identifiers` functions.
  - Add tests for identifiers exceeding 1024 characters in `test_parse_identifier` and `test_identifiers` functions.
