### PR TITLE
Add Verilog string parser

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,3 +1,5 @@
+mod string;
+
 use nom::{
     branch::alt,
     bytes::complete::{is_not, tag, take_until, take_while},
@@ -14,6 +16,8 @@ use nom::{
 use nom::character::complete::multispace0;
 
 use crate::keywords::{keyword_from_string, VerilogKeyword};
+
+pub use string::parse_verilog_string;
 
 #[derive(Debug, PartialEq)]
 enum VerilogBaseType {

--- a/src/parsers/string.rs
+++ b/src/parsers/string.rs
@@ -1,0 +1,35 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while_m_n},
+    character::complete::{char, none_of, one_of},
+    combinator::{map, map_res, opt, value},
+    multi::many0,
+    sequence::{delimited, preceded},
+    IResult,
+};
+
+fn parse_escape_sequence(input: &str) -> IResult<&str, char> {
+    preceded(
+        char('\\'),
+        alt((
+            value('\n', char('n')),
+            value('\t', char('t')),
+            value('\\', char('\\')),
+            value('\"', char('"')),
+            map_res(
+                preceded(char('d'), take_while_m_n(1, 3, |c: char| c.is_digit(8))),
+                |octal| u8::from_str_radix(octal, 8).map(|v| v as char),
+            ),
+            value('%', char('%')),
+        )),
+    )(input)
+}
+
+fn parse_string_content(input: &str) -> IResult<&str, String> {
+    many0(alt((parse_escape_sequence, none_of("\""))))(input)
+        .map(|(next_input, res)| (next_input, res.into_iter().collect()))
+}
+
+pub fn parse_verilog_string(input: &str) -> IResult<&str, String> {
+    delimited(char('"'), parse_string_content, char('"'))(input)
+}

--- a/src/tests/parsers_tests.rs
+++ b/src/tests/parsers_tests.rs
@@ -4,6 +4,7 @@ mod tests {
 
     use super::*;
     use crate::keywords::ALL_KEYWORDS;
+    use crate::parsers::parse_verilog_string;
 
     #[test]
     fn test_identifiers() {
@@ -79,5 +80,16 @@ mod tests {
     #[ignore]
     fn test_net_declaration() {
         net_declaration.parse("wire z").unwrap();
+    }
+
+    #[test]
+    fn test_parse_verilog_string() {
+        assert_eq!(parse_verilog_string("\"Hello, World!\""), Ok(("", "Hello, World!".to_string())));
+        assert_eq!(parse_verilog_string("\"Line1\\nLine2\""), Ok(("", "Line1\nLine2".to_string())));
+        assert_eq!(parse_verilog_string("\"Tab\\tCharacter\""), Ok(("", "Tab\tCharacter".to_string())));
+        assert_eq!(parse_verilog_string("\"Backslash\\\\Character\""), Ok(("", "Backslash\\Character".to_string())));
+        assert_eq!(parse_verilog_string("\"DoubleQuote\\\"Character\""), Ok(("", "DoubleQuote\"Character".to_string())));
+        assert_eq!(parse_verilog_string("\"Octal\\101Character\""), Ok(("", "OctalACharacter".to_string())));
+        assert_eq!(parse_verilog_string("\"Percent%%Character\""), Ok(("", "Percent%Character".to_string())));
     }
 }


### PR DESCRIPTION
Add Verilog string parsing functionality.

* **src/parsers/string.rs**
  - Implement `parse_verilog_string` function to parse Verilog strings.
  - Handle escape sequences like `\n`, `\t`, `\\`, `\"`, `\ddd`, and `%%`.

* **src/parsers.rs**
  - Add `mod string;` declaration.
  - Add `pub use string::parse_verilog_string;` declaration.

* **src/tests/parsers_tests.rs**
  - Add tests for `parse_verilog_string` function.
  - Test all special characters and the case of string escapes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/meawoppl/visilog/pull/14?shareId=5b0805fa-7191-48ce-a884-41d260d19edc).