### PR TITLE
Add better testing for expressions with bit select and part-select

### DIFF
--- a/src/parsers/expr.rs
+++ b/src/parsers/expr.rs
@@ -998,7 +998,7 @@ mod tests {
                     Box::new(Expression::Binary(
                         Box::new(Expression::Identifier(Identifier::new("b".to_string()))),
                         BinaryOperator::Addition,
-                        Box::new(Expression::Constant(VerilogConstant::from_int(3))),
+                        Box::new(Expression::Identifier(Identifier::new("c".to_string()))),
                     )),
                     Box::new(Expression::Binary(
                         Box::new(Expression::Constant(VerilogConstant::from_int(2))),

--- a/src/parsers/expr.rs
+++ b/src/parsers/expr.rs
@@ -991,6 +991,49 @@ mod tests {
                     Box::new(Expression::Constant(VerilogConstant::from_int(0))),
                 ),
             ),
+            (
+                "a[b+c:2+4]",
+                Expression::PartSelect(
+                    Identifier::new("a".to_string()),
+                    Box::new(Expression::Binary(
+                        Box::new(Expression::Identifier(Identifier::new("b".to_string()))),
+                        BinaryOperator::Addition,
+                        Box::new(Expression::Constant(VerilogConstant::from_int(3))),
+                    )),
+                    Box::new(Expression::Binary(
+                        Box::new(Expression::Constant(VerilogConstant::from_int(2))),
+                        BinaryOperator::Addition,
+                        Box::new(Expression::Constant(VerilogConstant::from_int(4))),
+                    )),
+                ),
+            ),
+            (
+                "~a[2:3]",
+                Expression::Unary(
+                    UnaryOperator::BitwiseNegation,
+                    Box::new(Expression::PartSelect(
+                        Identifier::new("a".to_string()),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(2))),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(3))),
+                    )),
+                ),
+            ),
+            (
+                "a[3:4] && b[4:5]",
+                Expression::Binary(
+                    Box::new(Expression::PartSelect(
+                        Identifier::new("a".to_string()),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(3))),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(4))),
+                    )),
+                    BinaryOperator::LogicalAnd,
+                    Box::new(Expression::PartSelect(
+                        Identifier::new("b".to_string()),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(4))),
+                        Box::new(Expression::Constant(VerilogConstant::from_int(5))),
+                    )),
+                ),
+            ),
         ];
 
         for (expr, expected) in expressions {


### PR DESCRIPTION
Add support for parsing bit select and part select expressions in `operand_no_ws` function.

* Add parsing for part select expressions like `a[b+c:2+4]`.
* Add parsing for part select expressions in larger expressions like `~a[2:3]` and `a[3:4] && b[4:5]`.
* Add unit tests for the new expressions.

