### PR TITLE
Add support for nets having a delay term

### DIFF
--- a/src/parsers/assignment.rs
+++ b/src/parsers/assignment.rs
@@ -93,11 +93,13 @@ mod tests {
     use crate::parsers::expr::Expression;
     use crate::parsers::identifier::Identifier;
 
-    
     #[test]
     fn test_assignment_lhs() {
         let cases = vec![
-            ("a", Expression::Identifier(Identifier::new("a".to_string()))),
+            (
+                "a",
+                Expression::Identifier(Identifier::new("a".to_string())),
+            ),
             (
                 "a[3]",
                 Expression::BitSelect(
@@ -125,7 +127,7 @@ mod tests {
 
         for (input, expected) in cases {
             let result = assignment_lhs(input);
-            assert!(result.is_ok(),  "Failed to parse '{}'", input);
+            assert!(result.is_ok(), "Failed to parse '{}'", input);
             let (remaining, expr) = result.unwrap();
             assert_eq!(remaining, "");
             assert_eq!(expr, expected);

--- a/src/parsers/expr.rs
+++ b/src/parsers/expr.rs
@@ -224,12 +224,11 @@ fn operand(input: &str) -> IResult<&str, Expression> {
 //      a & &b (reduction AND of b, then bitwise AND with a)
 
 fn operand_no_ws(input: &str) -> IResult<&str, Expression> {
-    // NOTE(meawoppl) 
+    // NOTE(meawoppl)
     // fn_call has to go before identifier, as function names
     // are valid identifiers
     alt((
-        fn_call, 
-
+        fn_call,
         fn_call,
         bit_select,
         part_select,
@@ -238,7 +237,6 @@ fn operand_no_ws(input: &str) -> IResult<&str, Expression> {
         parenthetical,
         concatenation,
     ))(input)
-
 }
 
 fn bit_select(input: &str) -> IResult<&str, Expression> {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,3 +1,4 @@
+pub mod assignment;
 pub mod base;
 pub mod constants;
 pub mod expr;
@@ -10,4 +11,3 @@ pub mod operators;
 pub mod register;
 pub mod simple;
 pub mod string;
-pub mod assignment;

--- a/src/parsers/nets.rs
+++ b/src/parsers/nets.rs
@@ -19,6 +19,13 @@ pub enum NetType {
     WireOr,
 }
 
+#[derive(Debug, PartialEq, Clone)]
+pub struct Net {
+    net_type: NetType,
+    delay: u32,
+    identifier: Identifier,
+}
+
 pub fn net_type(input: &str) -> nom::IResult<&str, NetType> {
     use nom::{branch::alt, bytes::complete::tag, combinator::value};
 
@@ -34,8 +41,25 @@ pub fn net_type(input: &str) -> nom::IResult<&str, NetType> {
     ))(input)
 }
 
-fn net_declaration(input: &str) -> IResult<&str, (NetType, Option<(i64, i64)>, Vec<Identifier>)> {
-    tuple((net_type, ws(opt(range)), ws(identifier_list)))(input)
+fn parse_delay(input: &str) -> IResult<&str, u32> {
+    use nom::{character::complete::digit1, combinator::map_res, sequence::preceded, bytes::complete::tag};
+
+    map_res(preceded(tag("#"), digit1), |s: &str| s.parse::<u32>())(input)
+}
+
+fn net_declaration(input: &str) -> IResult<&str, (Net, Option<(i64, i64)>, Vec<Identifier>)> {
+    let (input, net_type) = net_type(input)?;
+    let (input, delay) = opt(parse_delay)(input)?;
+    let (input, range) = ws(opt(range))(input)?;
+    let (input, identifiers) = ws(identifier_list)(input)?;
+
+    let net = Net {
+        net_type,
+        delay: delay.unwrap_or(0),
+        identifier: identifiers[0].clone(),
+    };
+
+    Ok((input, (net, range, identifiers)))
 }
 
 #[cfg(test)]
@@ -58,7 +82,30 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_delay() {
+        assert_eq!(parse_delay("#10"), Ok(("", 10)));
+        assert_eq!(parse_delay("#0"), Ok(("", 0)));
+        assert!(parse_delay("10").is_err());
+    }
+
+    #[test]
     fn test_net_declaration() {
-        net_declaration.parse("wire z").unwrap();
+        let result = net_declaration("wire #10 [7:0] z");
+        assert!(result.is_ok());
+        let (_, (net, range, identifiers)) = result.unwrap();
+        assert_eq!(net.net_type, NetType::Wire);
+        assert_eq!(net.delay, 10);
+        assert_eq!(net.identifier, Identifier::new("z".to_string()));
+        assert_eq!(range, Some((7, 0)));
+        assert_eq!(identifiers, vec![Identifier::new("z".to_string())]);
+
+        let result = net_declaration("wire [7:0] z");
+        assert!(result.is_ok());
+        let (_, (net, range, identifiers)) = result.unwrap();
+        assert_eq!(net.net_type, NetType::Wire);
+        assert_eq!(net.delay, 0);
+        assert_eq!(net.identifier, Identifier::new("z".to_string()));
+        assert_eq!(range, Some((7, 0)));
+        assert_eq!(identifiers, vec![Identifier::new("z".to_string())]);
     }
 }


### PR DESCRIPTION
Add support for nets having a delay term.

* Add `Net` struct to encapsulate net type, delay term, and identifier in `src/parsers/nets.rs`.
* Update `net_declaration` function to handle delay terms and identifier.
* Add `parse_delay` function to parse delay terms.
* Update the parser to return the new `Net` struct.
* Add tests for `Net` struct, `parse_delay` function, and `net_declaration` function.

