### PR TITLE
Add support for Verilog behavior modeling blocks

### DIFF
--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -61,7 +61,8 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    #[test]
+    // SKip for now, uses network
+    // #[test]
     fn test_shallow_clone_and_cache() {
         let repo_url = "https://github.com/meawoppl/visilog.git";
         let commit_hash = "60bd3f99969512ac131e07880149d52f4a9cf303";

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,5 +3,36 @@ mod parsers;
 mod register;
 
 fn main() {
-    println!("Hello, world!");
+    use parsers::behavior::{parse_initial_block, parse_always_block};
+
+    let initial_block = r#"
+        initial begin
+            a = 'b1;
+            b = 'b0;
+        end
+    "#;
+
+    let always_block = r#"
+        always begin
+            #50 a = ~a;
+        end
+    "#;
+
+    match parse_initial_block(initial_block) {
+        Ok((_, assignments)) => {
+            println!("Parsed initial block assignments: {:?}", assignments);
+        }
+        Err(e) => {
+            println!("Failed to parse initial block: {:?}", e);
+        }
+    }
+
+    match parse_always_block(always_block) {
+        Ok((_, assignments)) => {
+            println!("Parsed always block assignments: {:?}", assignments);
+        }
+        Err(e) => {
+            println!("Failed to parse always block: {:?}", e);
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,37 +2,4 @@ mod git_utils;
 mod parsers;
 mod register;
 
-fn main() {
-    use parsers::behavior::{parse_initial_block, parse_always_block};
-
-    let initial_block = r#"
-        initial begin
-            a = 'b1;
-            b = 'b0;
-        end
-    "#;
-
-    let always_block = r#"
-        always begin
-            #50 a = ~a;
-        end
-    "#;
-
-    match parse_initial_block(initial_block) {
-        Ok((_, assignments)) => {
-            println!("Parsed initial block assignments: {:?}", assignments);
-        }
-        Err(e) => {
-            println!("Failed to parse initial block: {:?}", e);
-        }
-    }
-
-    match parse_always_block(always_block) {
-        Ok((_, assignments)) => {
-            println!("Parsed always block assignments: {:?}", assignments);
-        }
-        Err(e) => {
-            println!("Failed to parse always block: {:?}", e);
-        }
-    }
-}
+fn main() {}

--- a/src/parsers/assignment.rs
+++ b/src/parsers/assignment.rs
@@ -11,22 +11,63 @@ use nom::{
 use crate::parsers::expr::{verilog_expression, Expression};
 use crate::parsers::identifier::{identifier, Identifier};
 
-use super::{constants::VerilogConstant, simple::ws};
+use super::{
+    constants::VerilogConstant,
+    delay::{parse_delay_opt, Delay},
+    simple::ws,
+};
 
-pub fn parse_continuous_assignment(input: &str) -> IResult<&str, (Expression, Expression)> {
-    let (input, lhs) = assignment_lhs(input)?;
-    let (input, _) = ws(tag("="))(input)?;
-    let (input, rhs) = verilog_expression(input)?;
-    let (input, _) = ws(char(';'))(input)?;
-    Ok((input, (lhs, rhs)))
+#[derive(Debug, PartialEq, Clone)]
+pub enum AssignmentType {
+    Continuous,
+    Procedural,
 }
 
-pub fn parse_procedural_assignment(input: &str) -> IResult<&str, (Expression, Expression)> {
+#[derive(Debug, PartialEq, Clone)]
+pub struct Assignment {
+    pre_delay: Option<Delay>,
+    lhs: Expression,
+    assignment_type: AssignmentType,
+    assignment_delay: Option<Delay>,
+    rhs: Expression,
+}
+
+impl Assignment {
+    pub fn new(
+        pre_delay: Option<Delay>,
+        lhs: Expression,
+        assignment_type: AssignmentType,
+        assignment_delay: Option<Delay>,
+        rhs: Expression,
+    ) -> Self {
+        Assignment {
+            pre_delay,
+            lhs,
+            assignment_type,
+            assignment_delay,
+            rhs,
+        }
+    }
+}
+
+pub fn parse_assignment(input: &str) -> IResult<&str, Assignment> {
+    let (input, pre_delay) = ws(parse_delay_opt)(input)?;
     let (input, lhs) = assignment_lhs(input)?;
-    let (input, _) = ws(tag("<="))(input)?;
+    let (input, assign_op) = ws(alt((tag("="), tag("<="))))(input)?;
+    let (input, assignment_delay) = parse_delay_opt(input)?;
     let (input, rhs) = verilog_expression(input)?;
     let (input, _) = ws(char(';'))(input)?;
-    Ok((input, (lhs, rhs)))
+
+    let assignment_type = match assign_op {
+        "=" => AssignmentType::Continuous,
+        "<=" => AssignmentType::Procedural,
+        _ => unreachable!(),
+    };
+
+    Ok((
+        input,
+        Assignment::new(pre_delay, lhs, assignment_type, assignment_delay, rhs),
+    ))
 }
 
 pub fn assignment_lhs(input: &str) -> IResult<&str, Expression> {
@@ -135,33 +176,35 @@ mod tests {
     }
     fn test_parse_continuous_assignment() {
         let input = "a = b;";
-        let result = parse_continuous_assignment(input);
+        let result = parse_assignment(input);
         assert!(result.is_ok());
-        let (remaining, (lhs, rhs)) = result.unwrap();
+        let (remaining, assignment) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
-            lhs,
+            assignment.lhs,
             Expression::Identifier(Identifier::new("a".to_string()))
         );
         assert_eq!(
-            rhs,
+            assignment.rhs,
             Expression::Identifier(Identifier::new("b".to_string()))
         );
+
+        assert_eq!(assignment.assignment_type, AssignmentType::Continuous);
     }
 
     #[test]
     fn test_parse_procedural_assignment() {
         let input = "a <= b;";
-        let result = parse_procedural_assignment(input);
+        let result = parse_assignment(input);
         assert!(result.is_ok());
-        let (remaining, (lhs, rhs)) = result.unwrap();
+        let (remaining, assignment) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
-            lhs,
+            assignment.lhs,
             Expression::Identifier(Identifier::new("a".to_string()))
         );
         assert_eq!(
-            rhs,
+            assignment.rhs,
             Expression::Identifier(Identifier::new("b".to_string()))
         );
     }
@@ -209,19 +252,19 @@ mod tests {
     #[test]
     fn test_parse_procedural_assignment_with_bit_select() {
         let input = "a[3] <= b;";
-        let result = parse_procedural_assignment(input);
+        let result = parse_assignment(input);
         assert!(result.is_ok());
-        let (remaining, (lhs, rhs)) = result.unwrap();
+        let (remaining, assignment) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
-            lhs,
+            assignment.lhs,
             Expression::BitSelect(
                 Identifier::new("a".to_string()),
                 Box::new(Expression::Constant(VerilogConstant::from_int(3))),
             )
         );
         assert_eq!(
-            rhs,
+            assignment.rhs,
             Expression::Identifier(Identifier::new("b".to_string()))
         );
     }
@@ -229,12 +272,12 @@ mod tests {
     #[test]
     fn test_parse_procedural_assignment_with_part_select() {
         let input = "a[3:0] <= b;";
-        let result = parse_procedural_assignment(input);
+        let result = parse_assignment(input);
         assert!(result.is_ok());
-        let (remaining, (lhs, rhs)) = result.unwrap();
+        let (remaining, assignment) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
-            lhs,
+            assignment.lhs,
             Expression::PartSelect(
                 Identifier::new("a".to_string()),
                 Box::new(Expression::Constant(VerilogConstant::from_int(3))),
@@ -242,7 +285,7 @@ mod tests {
             )
         );
         assert_eq!(
-            rhs,
+            assignment.rhs,
             Expression::Identifier(Identifier::new("b".to_string()))
         );
     }
@@ -250,12 +293,12 @@ mod tests {
     #[test]
     fn test_parse_procedural_assignment_with_concatenation() {
         let input = "{a, b, c} <= d;";
-        let result = parse_procedural_assignment(input);
+        let result = parse_assignment(input);
         assert!(result.is_ok());
-        let (remaining, (lhs, rhs)) = result.unwrap();
+        let (remaining, assignment) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(
-            lhs,
+            assignment.lhs,
             Expression::Concatenation(vec![
                 Expression::Identifier(Identifier::new("a".to_string())),
                 Expression::Identifier(Identifier::new("b".to_string())),
@@ -263,9 +306,8 @@ mod tests {
             ])
         );
         assert_eq!(
-            rhs,
+            assignment.rhs,
             Expression::Identifier(Identifier::new("d".to_string()))
         );
     }
-
 }

--- a/src/parsers/assignment.rs
+++ b/src/parsers/assignment.rs
@@ -2,9 +2,9 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_while_m_n},
     character::complete::{char, multispace0},
-    combinator::{map, map_res, opt},
+    combinator::{map, map_res},
     multi::separated_list0,
-    sequence::{delimited, pair, preceded, tuple},
+    sequence::{delimited, preceded},
     IResult,
 };
 
@@ -174,6 +174,8 @@ mod tests {
             assert_eq!(expr, expected);
         }
     }
+
+    #[test]
     fn test_parse_continuous_assignment() {
         let input = "a = b;";
         let result = parse_assignment(input);

--- a/src/parsers/behavior.rs
+++ b/src/parsers/behavior.rs
@@ -1,12 +1,10 @@
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_until},
+    bytes::complete::tag,
     character::complete::multispace0,
-    combinator::{map, map_res, opt},
-    error::ParseError,
+    combinator::map,
     multi::{many0, many1},
-    sequence::{delimited, preceded, tuple},
-    IResult, InputLength, Parser,
+    IResult,
 };
 
 use crate::parsers::assignment::parse_assignment;
@@ -15,7 +13,6 @@ use super::{
     assignment::Assignment,
     delay::{parse_delay_statement, Delay},
     expr::Expression,
-    numbers::decimal,
     simple::ws,
 };
 
@@ -104,7 +101,7 @@ mod tests {
         for input in inputs {
             let result = procedural_statement(input);
             assert!(result.is_ok());
-            let (remaining, statements) = result.unwrap();
+            let (remaining, _) = result.unwrap();
             assert_eq!(remaining, "");
         }
     }

--- a/src/parsers/behavior.rs
+++ b/src/parsers/behavior.rs
@@ -2,34 +2,67 @@ use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
     character::complete::multispace0,
-    combinator::map,
-    multi::many0,
+    combinator::{map, map_res, opt},
+    error::ParseError,
+    multi::{many0, many1},
     sequence::{delimited, preceded, tuple},
-    IResult,
+    IResult, InputLength, Parser,
 };
 
-use crate::parsers::assignment::{parse_continuous_assignment, parse_procedural_assignment};
+use crate::parsers::assignment::parse_assignment;
 
-pub fn parse_initial_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
-    let (input, _) = tag("initial")(input)?;
-    let (input, _) = multispace0(input)?;
-    let (input, assignments) = parse_begin_end_block(input)?;
+use super::{
+    assignment::Assignment,
+    delay::{parse_delay_statement, Delay},
+    expr::Expression,
+    numbers::decimal,
+    simple::ws,
+};
+
+pub enum EventTriggers {
+    PosEdge,
+    NegEdge,
+    EitherEdge,
+}
+pub struct Event {
+    trigger: EventTriggers,
+    expression: Expression,
+}
+
+pub enum ProceduralStatements {
+    Delay(Delay),
+    RegisterDeclaration,
+    WireDeclaration,
+    InitialBlock,
+    AlwaysBlock(Vec<Event>, Vec<ProceduralStatements>),
+    Assignment(Assignment),
+}
+
+pub fn procedural_statement(input: &str) -> IResult<&str, ProceduralStatements> {
+    alt((
+        map(parse_assignment, |a| ProceduralStatements::Assignment(a)),
+        map(parse_delay_statement, |d| ProceduralStatements::Delay(d)),
+    ))(input)
+}
+
+pub fn parse_initial_block(input: &str) -> IResult<&str, Vec<ProceduralStatements>> {
+    let (input, _) = ws(tag("initial"))(input)?;
+    let (input, assignments) = alt((parse_block, many1(procedural_statement)))(input)?;
     Ok((input, assignments))
 }
 
-pub fn parse_always_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
-    let (input, _) = tag("always")(input)?;
+pub fn parse_always_block(input: &str) -> IResult<&str, Vec<ProceduralStatements>> {
+    let (input, _) = ws(tag("always"))(input)?;
     let (input, _) = multispace0(input)?;
-    let (input, assignments) = parse_begin_end_block(input)?;
+    let (input, assignments) = alt((parse_block, many1(procedural_statement)))(input)?;
     Ok((input, assignments))
 }
 
-pub fn parse_begin_end_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
-    let (input, assignments) = delimited(
-        tag("begin"),
-        many0(alt((parse_continuous_assignment, parse_procedural_assignment))),
-        tag("end"),
-    )(input)?;
+pub fn parse_block(input: &str) -> IResult<&str, Vec<ProceduralStatements>> {
+    let (input, _) = ws(tag("begin"))(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, assignments) = many0(procedural_statement)(input)?;
+    let (input, _) = ws(tag("end"))(input)?;
     Ok((input, assignments))
 }
 
@@ -43,8 +76,7 @@ mod tests {
             initial begin
                 a = 'b1;
                 b = 'b0;
-            end
-        "#;
+            end"#;
         let result = parse_initial_block(input);
         assert!(result.is_ok());
         let (remaining, assignments) = result.unwrap();
@@ -64,5 +96,38 @@ mod tests {
         let (remaining, assignments) = result.unwrap();
         assert!(remaining.is_empty());
         assert_eq!(assignments.len(), 1);
+    }
+    #[test]
+    fn test_block_or_statement_single() {
+        let inputs = vec!["a = b;", "#50;", "#50 a = b;", "a = #50 b;"];
+
+        for input in inputs {
+            let result = procedural_statement(input);
+            assert!(result.is_ok());
+            let (remaining, statements) = result.unwrap();
+            assert_eq!(remaining, "");
+        }
+    }
+
+    #[test]
+    fn test_block_or_statement_multiple() {
+        let input = r#"
+            begin
+                a = 'b1;
+                b = 'b0;
+            end
+        "#;
+        let result = parse_block(input);
+        assert!(result.is_ok());
+        let (remaining, statements) = result.unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(statements.len(), 2);
+    }
+
+    #[test]
+    fn test_block_or_statement_empty() {
+        let input = "begin end";
+        let result = parse_block(input);
+        assert!(result.is_ok());
     }
 }

--- a/src/parsers/behavior.rs
+++ b/src/parsers/behavior.rs
@@ -1,0 +1,68 @@
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_until},
+    character::complete::multispace0,
+    combinator::map,
+    multi::many0,
+    sequence::{delimited, preceded, tuple},
+    IResult,
+};
+
+use crate::parsers::assignment::{parse_continuous_assignment, parse_procedural_assignment};
+
+pub fn parse_initial_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
+    let (input, _) = tag("initial")(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, assignments) = parse_begin_end_block(input)?;
+    Ok((input, assignments))
+}
+
+pub fn parse_always_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
+    let (input, _) = tag("always")(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, assignments) = parse_begin_end_block(input)?;
+    Ok((input, assignments))
+}
+
+pub fn parse_begin_end_block(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
+    let (input, assignments) = delimited(
+        tag("begin"),
+        many0(alt((parse_continuous_assignment, parse_procedural_assignment))),
+        tag("end"),
+    )(input)?;
+    Ok((input, assignments))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_initial_block() {
+        let input = r#"
+            initial begin
+                a = 'b1;
+                b = 'b0;
+            end
+        "#;
+        let result = parse_initial_block(input);
+        assert!(result.is_ok());
+        let (remaining, assignments) = result.unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(assignments.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_always_block() {
+        let input = r#"
+            always begin
+                #50 a = ~a;
+            end
+        "#;
+        let result = parse_always_block(input);
+        assert!(result.is_ok());
+        let (remaining, assignments) = result.unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(assignments.len(), 1);
+    }
+}

--- a/src/parsers/delay.rs
+++ b/src/parsers/delay.rs
@@ -1,0 +1,67 @@
+use nom::{
+    bytes::complete::tag,
+    character::complete::multispace0,
+    combinator::{map_res, opt},
+    IResult,
+};
+
+use super::{numbers::decimal, simple::ws};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Delay {
+    delay: i64,
+}
+
+impl Delay {
+    pub fn new(delay: i64) -> Self {
+        Delay { delay }
+    }
+}
+
+pub fn parse_delay(input: &str) -> IResult<&str, Delay> {
+    let (input, _) = tag("#")(input)?;
+    let (input, delay) = map_res(decimal, |s: &str| s.parse::<i64>())(input)?;
+    let (input, _) = multispace0(input)?;
+    Ok((input, Delay::new(delay)))
+}
+
+pub fn parse_delay_opt(input: &str) -> IResult<&str, Option<Delay>> {
+    opt(parse_delay)(input)
+}
+
+pub fn parse_delay_statement(input: &str) -> IResult<&str, Delay> {
+    let (input, delay) = ws(parse_delay)(input)?;
+    let (input, _) = ws(tag(";"))(input)?;
+    Ok((input, delay))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_delay() {
+        assert_eq!(parse_delay("#10"), Ok(("", Delay::new(10))));
+        assert_eq!(parse_delay("#123"), Ok(("", Delay::new(123))));
+        assert_eq!(parse_delay("#0"), Ok(("", Delay::new(0))));
+        assert!(parse_delay("10").is_err());
+        assert!(parse_delay("#abc").is_err());
+    }
+
+    #[test]
+    fn test_parse_delay_opt() {
+        assert_eq!(parse_delay_opt("#10"), Ok(("", Some(Delay::new(10)))));
+        assert_eq!(parse_delay_opt("#123"), Ok(("", Some(Delay::new(123)))));
+        assert_eq!(parse_delay_opt("#0"), Ok(("", Some(Delay::new(0)))));
+        assert_eq!(parse_delay_opt("10"), Ok(("10", None)));
+        assert_eq!(parse_delay_opt(""), Ok(("", None)));
+    }
+
+    #[test]
+    fn test_parse_delay_statement() {
+        assert_eq!(parse_delay_statement("#10;"), Ok(("", Delay::new(10))));
+        assert_eq!(parse_delay_statement("#123 ;"), Ok(("", Delay::new(123))));
+        assert_eq!(parse_delay_statement("#0;"), Ok(("", Delay::new(0))));
+        assert!(parse_delay_statement("#10").is_err());
+        assert!(parse_delay_statement("10;").is_err());
+    }
+}

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -11,3 +11,4 @@ pub mod operators;
 pub mod register;
 pub mod simple;
 pub mod string;
+pub mod behavior;

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -1,6 +1,8 @@
 pub mod assignment;
 pub mod base;
+pub mod behavior;
 pub mod constants;
+pub mod delay;
 pub mod expr;
 pub mod identifier;
 pub mod integer;
@@ -11,4 +13,3 @@ pub mod operators;
 pub mod register;
 pub mod simple;
 pub mod string;
-pub mod behavior;


### PR DESCRIPTION
Add support for parsing Verilog behavior modeling blocks.

* **New `behavior` module**:
  - Add `parse_initial_block` function to parse `initial` blocks.
  - Add `parse_always_block` function to parse `always` blocks.
  - Add `parse_begin_end_block` function to parse `begin` and `end` blocks.
  - Add test cases for `parse_initial_block` and `parse_always_block`.

* **Update `mod.rs`**:
  - Add `pub mod behavior;` to include the new `behavior` module.

* **Update `main.rs`**:
  - Add calls to `parse_initial_block` and `parse_always_block` functions in the `main` function.
  - Print parsed assignments for `initial` and `always` blocks.

