### PR TITLE
Add validator for Verilog modules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod git_utils;
 mod parsers;
 mod register;
+mod validator;
 
 fn main() {}

--- a/src/parsers/modules.rs
+++ b/src/parsers/modules.rs
@@ -100,6 +100,10 @@ pub fn parse_module_declaration(input: &str) -> IResult<&str, VerilogModule> {
     ))
 }
 
+pub fn parse_verilog(input: &str) -> IResult<&str, VerilogModule> {
+    parse_module_declaration(input)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::parsers::helpers::assert_parses_to;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,74 @@
+use crate::parsers::modules::VerilogModule;
+use crate::parsers::identifier::Identifier;
+use crate::parsers::assignment::AssignmentType;
+use crate::parsers::behavior::ProceduralStatements;
+
+pub mod validator {
+    use super::*;
+
+    pub fn validate_module(module: &VerilogModule) -> Result<(), String> {
+        validate_identifiers(&module)?;
+        validate_initial_blocks(&module)?;
+        validate_always_blocks(&module)?;
+        Ok(())
+    }
+
+    fn validate_identifiers(module: &VerilogModule) -> Result<(), String> {
+        let mut defined_identifiers = vec![];
+
+        for port in &module.ports {
+            defined_identifiers.push(&port.identifier);
+        }
+
+        for statement in &module.statements {
+            match statement {
+                ProceduralStatements::Assignment(assignment) => {
+                    if !defined_identifiers.contains(&assignment.lhs) {
+                        return Err(format!("Undefined identifier: {:?}", assignment.lhs));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_initial_blocks(module: &VerilogModule) -> Result<(), String> {
+        for statement in &module.statements {
+            if let ProceduralStatements::InitialBlock(assignments) = statement {
+                for assignment in assignments {
+                    if let ProceduralStatements::Assignment(assignment) = assignment {
+                        if assignment.assignment_type != AssignmentType::Continuous {
+                            return Err(format!(
+                                "Invalid assignment in initial block: {:?}",
+                                assignment
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_always_blocks(module: &VerilogModule) -> Result<(), String> {
+        for statement in &module.statements {
+            if let ProceduralStatements::AlwaysBlock(_, assignments) = statement {
+                for assignment in assignments {
+                    if let ProceduralStatements::Assignment(assignment) = assignment {
+                        if assignment.assignment_type != AssignmentType::Procedural {
+                            return Err(format!(
+                                "Invalid assignment in always block: {:?}",
+                                assignment
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,7 +1,7 @@
-use crate::parsers::modules::VerilogModule;
-use crate::parsers::identifier::Identifier;
 use crate::parsers::assignment::AssignmentType;
 use crate::parsers::behavior::ProceduralStatements;
+use crate::parsers::identifier::Identifier;
+use crate::parsers::modules::VerilogModule;
 
 pub mod validator {
     use super::*;

--- a/tests/validator_tests.rs
+++ b/tests/validator_tests.rs
@@ -1,8 +1,8 @@
-use crate::validator::validate_module;
-use crate::parsers::modules::{VerilogModule, Port, PortDirection, NetType};
-use crate::parsers::identifier::Identifier;
 use crate::parsers::assignment::{Assignment, AssignmentType};
-use crate::parsers::behavior::{ProceduralStatements, Event, EventTriggers};
+use crate::parsers::behavior::{Event, EventTriggers, ProceduralStatements};
+use crate::parsers::identifier::Identifier;
+use crate::parsers::modules::{NetType, Port, PortDirection, VerilogModule};
+use crate::validator::validate_module;
 
 #[test]
 fn test_validate_identifiers() {
@@ -20,15 +20,13 @@ fn test_validate_identifiers() {
                 identifier: Identifier::new("b".to_string()),
             },
         ],
-        statements: vec![
-            ProceduralStatements::Assignment(Assignment {
-                pre_delay: None,
-                lhs: Identifier::new("a".to_string()).into(),
-                assignment_type: AssignmentType::Continuous,
-                assignment_delay: None,
-                rhs: Identifier::new("b".to_string()).into(),
-            }),
-        ],
+        statements: vec![ProceduralStatements::Assignment(Assignment {
+            pre_delay: None,
+            lhs: Identifier::new("a".to_string()).into(),
+            assignment_type: AssignmentType::Continuous,
+            assignment_delay: None,
+            rhs: Identifier::new("b".to_string()).into(),
+        })],
     };
 
     assert!(validate_module(&module).is_ok());
@@ -50,17 +48,15 @@ fn test_validate_initial_blocks() {
                 identifier: Identifier::new("b".to_string()),
             },
         ],
-        statements: vec![
-            ProceduralStatements::InitialBlock(vec![
-                ProceduralStatements::Assignment(Assignment {
-                    pre_delay: None,
-                    lhs: Identifier::new("a".to_string()).into(),
-                    assignment_type: AssignmentType::Continuous,
-                    assignment_delay: None,
-                    rhs: Identifier::new("b".to_string()).into(),
-                }),
-            ]),
-        ],
+        statements: vec![ProceduralStatements::InitialBlock(vec![
+            ProceduralStatements::Assignment(Assignment {
+                pre_delay: None,
+                lhs: Identifier::new("a".to_string()).into(),
+                assignment_type: AssignmentType::Continuous,
+                assignment_delay: None,
+                rhs: Identifier::new("b".to_string()).into(),
+            }),
+        ])],
     };
 
     assert!(validate_module(&module).is_ok());
@@ -82,25 +78,19 @@ fn test_validate_always_blocks() {
                 identifier: Identifier::new("b".to_string()),
             },
         ],
-        statements: vec![
-            ProceduralStatements::AlwaysBlock(
-                vec![
-                    Event {
-                        trigger: EventTriggers::PosEdge,
-                        expression: Identifier::new("clk".to_string()).into(),
-                    },
-                ],
-                vec![
-                    ProceduralStatements::Assignment(Assignment {
-                        pre_delay: None,
-                        lhs: Identifier::new("a".to_string()).into(),
-                        assignment_type: AssignmentType::Procedural,
-                        assignment_delay: None,
-                        rhs: Identifier::new("b".to_string()).into(),
-                    }),
-                ],
-            ),
-        ],
+        statements: vec![ProceduralStatements::AlwaysBlock(
+            vec![Event {
+                trigger: EventTriggers::PosEdge,
+                expression: Identifier::new("clk".to_string()).into(),
+            }],
+            vec![ProceduralStatements::Assignment(Assignment {
+                pre_delay: None,
+                lhs: Identifier::new("a".to_string()).into(),
+                assignment_type: AssignmentType::Procedural,
+                assignment_delay: None,
+                rhs: Identifier::new("b".to_string()).into(),
+            })],
+        )],
     };
 
     assert!(validate_module(&module).is_ok());

--- a/tests/validator_tests.rs
+++ b/tests/validator_tests.rs
@@ -1,0 +1,107 @@
+use crate::validator::validate_module;
+use crate::parsers::modules::{VerilogModule, Port, PortDirection, NetType};
+use crate::parsers::identifier::Identifier;
+use crate::parsers::assignment::{Assignment, AssignmentType};
+use crate::parsers::behavior::{ProceduralStatements, Event, EventTriggers};
+
+#[test]
+fn test_validate_identifiers() {
+    let module = VerilogModule {
+        identifier: Identifier::new("test_module".to_string()),
+        ports: vec![
+            Port {
+                direction: PortDirection::Input,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("a".to_string()),
+            },
+            Port {
+                direction: PortDirection::Output,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("b".to_string()),
+            },
+        ],
+        statements: vec![
+            ProceduralStatements::Assignment(Assignment {
+                pre_delay: None,
+                lhs: Identifier::new("a".to_string()).into(),
+                assignment_type: AssignmentType::Continuous,
+                assignment_delay: None,
+                rhs: Identifier::new("b".to_string()).into(),
+            }),
+        ],
+    };
+
+    assert!(validate_module(&module).is_ok());
+}
+
+#[test]
+fn test_validate_initial_blocks() {
+    let module = VerilogModule {
+        identifier: Identifier::new("test_module".to_string()),
+        ports: vec![
+            Port {
+                direction: PortDirection::Input,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("a".to_string()),
+            },
+            Port {
+                direction: PortDirection::Output,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("b".to_string()),
+            },
+        ],
+        statements: vec![
+            ProceduralStatements::InitialBlock(vec![
+                ProceduralStatements::Assignment(Assignment {
+                    pre_delay: None,
+                    lhs: Identifier::new("a".to_string()).into(),
+                    assignment_type: AssignmentType::Continuous,
+                    assignment_delay: None,
+                    rhs: Identifier::new("b".to_string()).into(),
+                }),
+            ]),
+        ],
+    };
+
+    assert!(validate_module(&module).is_ok());
+}
+
+#[test]
+fn test_validate_always_blocks() {
+    let module = VerilogModule {
+        identifier: Identifier::new("test_module".to_string()),
+        ports: vec![
+            Port {
+                direction: PortDirection::Input,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("a".to_string()),
+            },
+            Port {
+                direction: PortDirection::Output,
+                net_type: Some(NetType::Wire),
+                identifier: Identifier::new("b".to_string()),
+            },
+        ],
+        statements: vec![
+            ProceduralStatements::AlwaysBlock(
+                vec![
+                    Event {
+                        trigger: EventTriggers::PosEdge,
+                        expression: Identifier::new("clk".to_string()).into(),
+                    },
+                ],
+                vec![
+                    ProceduralStatements::Assignment(Assignment {
+                        pre_delay: None,
+                        lhs: Identifier::new("a".to_string()).into(),
+                        assignment_type: AssignmentType::Procedural,
+                        assignment_delay: None,
+                        rhs: Identifier::new("b".to_string()).into(),
+                    }),
+                ],
+            ),
+        ],
+    };
+
+    assert!(validate_module(&module).is_ok());
+}


### PR DESCRIPTION
Add validation for Verilog modules.

* **Validator Module**: 
  - Add `src/validator.rs` to define a new module `validator`.
  - Implement `validate_module` function to validate Verilog modules.
  - Implement `validate_identifiers` function to check if all identifiers are defined.
  - Implement `validate_initial_blocks` function to check for direct "=" assignments in initial blocks.
  - Implement `validate_always_blocks` function to check for continuous assignments in always blocks.

* **Parser Module**:
  - Add `parse_verilog` function to `src/parsers/modules.rs` to parse Verilog modules.

